### PR TITLE
Add Firefox compatibility

### DIFF
--- a/amigoscode-foreground.js
+++ b/amigoscode-foreground.js
@@ -1,3 +1,6 @@
+if (chrome) {
+	browser = chrome;
+}
 initiate();
 
 function initiate() {
@@ -76,7 +79,7 @@ function showInfoOverlay(command) {
 
 function mainScript() {
 	console.log("Script has been injected");
-	chrome.runtime.sendMessage("Video loaded");
+	browser.runtime.sendMessage("Video loaded");
 
 	// All commands handled via the DOM
 	domElementCommands = {
@@ -86,10 +89,10 @@ function mainScript() {
 			// }
 			if (video.paused) {
 				pauseElement.click();
-				chrome.runtime.sendMessage(video.paused);
+				browser.runtime.sendMessage(video.paused);
 			} else {
 				pauseElement.click();
-				chrome.runtime.sendMessage(video.paused);
+				browser.runtime.sendMessage(video.paused);
 			}
 		},
 		bRewind: () => {
@@ -160,15 +163,15 @@ function mainScript() {
 
 	// MutationObserver doesn't seem to work for every website's video attributes. Registers clicks on video container and sends state of video paused attribute instead.
 	pauseElement.addEventListener("click", () => {
-		chrome.runtime.sendMessage(video.paused);
+		browser.runtime.sendMessage(video.paused);
 	});
 
 	// Creates a MutationsObserver to monitor video DOM element
 	const observer = new MutationObserver((mutations) => {
 		// Restarts script if video 'src' changes
 		if (mutations[0].attributeName === "src") {
-			chrome.runtime.onMessage.removeListener(commandHandler);
-			chrome.runtime.onMessage.removeListener(videoPausedHandler);
+			browser.runtime.onMessage.removeListener(commandHandler);
+			browser.runtime.onMessage.removeListener(videoPausedHandler);
 			window.scriptInjected = false;
 			initiate();
 		}
@@ -183,7 +186,7 @@ function mainScript() {
 				video.playbackRate = playbackRateTemp;
 			}
 		}
-		chrome.runtime.sendMessage(video.paused);
+		browser.runtime.sendMessage(video.paused);
 	});
 
 	observer.observe(video.parentElement, {
@@ -193,7 +196,7 @@ function mainScript() {
 		attributeFilter: ["src"],
 	});
 
-	chrome.runtime.onMessage.addListener(commandHandler);
+	browser.runtime.onMessage.addListener(commandHandler);
 
 	function commandHandler(request, sender, sendResponse) {
 		// Uses incoming message as a dynamic key to call command function
@@ -204,7 +207,7 @@ function mainScript() {
 	}
 
 	// Prevents background.js from running scripts on other windows when video is still playing in current window.
-	chrome.runtime.onMessage.addListener(videoPausedHandler);
+	browser.runtime.onMessage.addListener(videoPausedHandler);
 
 	function videoPausedHandler(request, sender, sendResponse) {
 		if (request.message === "Is your tab's video playing?") {

--- a/udemy-foreground.js
+++ b/udemy-foreground.js
@@ -1,3 +1,6 @@
+if (chrome) {
+	browser = chrome;
+}
 initiate();
 
 function initiate() {
@@ -84,17 +87,17 @@ function showInfoOverlay(command) {
 
 function mainScript() {
 	console.log("Script has been injected");
-	chrome.runtime.sendMessage("Video loaded");
+	browser.runtime.sendMessage("Video loaded");
 
 	// All commands handled via the DOM
 	domElementCommands = {
 		aPausePlay: () => {
 			if (video.paused) {
 				video.play();
-				chrome.runtime.sendMessage(video.paused);
+				browser.runtime.sendMessage(video.paused);
 			} else {
 				video.pause();
-				chrome.runtime.sendMessage(video.paused);
+				browser.runtime.sendMessage(video.paused);
 			}
 		},
 		bRewind: () => {
@@ -183,7 +186,7 @@ function mainScript() {
 				video.playbackRate = playbackRateTemp;
 			}
 			/* -------------------------------- */
-			chrome.runtime.sendMessage(video.paused);
+			browser.runtime.sendMessage(video.paused);
 			playPauseTimeoutFlag = true;
 			playPauseTimeout = setTimeout(() => {
 				playPauseTimeoutFlag = false;
@@ -191,8 +194,8 @@ function mainScript() {
 		}
 	}
 
-	chrome.runtime.onMessage.addListener(commandHandler);
-	chrome.runtime.onMessage.addListener(refreshHandler);
+	browser.runtime.onMessage.addListener(commandHandler);
+	browser.runtime.onMessage.addListener(refreshHandler);
 
 	function commandHandler(request, sender, sendResponse) {
 		// Uses incoming message as a dynamic key to call command function
@@ -204,15 +207,15 @@ function mainScript() {
 
 	function refreshHandler(request, sender, sendResponse) {
 		if (request.message === "Refreshing") {
-			chrome.runtime.onMessage.removeListener(commandHandler);
+			browser.runtime.onMessage.removeListener(commandHandler);
 			window.scriptInjected = false;
 			// initiate();
-			chrome.runtime.onMessage.removeListener(refreshHandler);
+			browser.runtime.onMessage.removeListener(refreshHandler);
 		}
 	}
 
 	// Prevents background.js from running scripts on other windows when video is still playing in current window.
-	chrome.runtime.onMessage.addListener(videoPausedHandler);
+	browser.runtime.onMessage.addListener(videoPausedHandler);
 
 	function videoPausedHandler(request, sender, sendResponse) {
 		if (request.message === "Is your tab's video playing?") {
@@ -245,8 +248,8 @@ function mainTextScript() {
 		},
 	};
 
-	chrome.runtime.onMessage.addListener(commandHandler);
-	chrome.runtime.onMessage.addListener(refreshHandler);
+	browser.runtime.onMessage.addListener(commandHandler);
+	browser.runtime.onMessage.addListener(refreshHandler);
 
 	function commandHandler(request, sender, sendResponse) {
 		// Uses incoming message as a dynamic key to call command function
@@ -258,10 +261,10 @@ function mainTextScript() {
 
 	function refreshHandler(request, sender, sendResponse) {
 		if (request.message === "Refreshing") {
-			chrome.runtime.onMessage.removeListener(commandHandler);
+			browser.runtime.onMessage.removeListener(commandHandler);
 			window.scriptInjected = false;
 			// initiate();
-			chrome.runtime.onMessage.removeListener(refreshHandler);
+			browser.runtime.onMessage.removeListener(refreshHandler);
 		}
 	}
 }

--- a/youtube-foreground.js
+++ b/youtube-foreground.js
@@ -1,8 +1,11 @@
+if (chrome) {
+	browser = chrome;
+}
 if (!window.scriptInjected) {
 	window.scriptInjected = true; //Prevents script from being run multiple times per tab
 
 	console.log("Script has been injected");
-	chrome.runtime.sendMessage("Video loaded");
+	browser.runtime.sendMessage("Video loaded");
 
 	video = document.querySelector("video");
 	videoParent = video.parentElement;
@@ -24,7 +27,7 @@ if (!window.scriptInjected) {
 	// Creates a MutationsObserver to monitor video DOM element
 	const observer = new MutationObserver((mutations) => {
 		// Mutations object used for debugging
-		chrome.runtime.sendMessage(video.paused);
+		browser.runtime.sendMessage(video.paused);
 	});
 	observer.observe(video, {
 		attributes: true,
@@ -101,7 +104,7 @@ if (!window.scriptInjected) {
 		},
 	};
 
-	chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+	browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
 		// Uses incoming message as a dynamic key to dispatch keypress or call command function
 		if (Object.keys(shortcuts).includes(request.message)) {
 			console.log("Command received: ", request.message);
@@ -114,7 +117,7 @@ if (!window.scriptInjected) {
 	});
 
 	// Prevents background.js from running scripts on other windows when video is still playing in current window.
-	chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+	browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
 		if (request.message === "Is your tab's video playing?") {
 			if (!video.paused) {
 				sendResponse("Yes, don't run a script on the other window yet.");


### PR DESCRIPTION
Fortunately the APIs are largely compatible with each other, the only difference is that in Firefox (and Edge) the API is under the `browser` namespace, while in Chrome and Opera it's under `chrome`

`browser` seems more general, so made that the default and made it defer to `chrome` only if that object exists

Also had to modify `*.tabs.getAllInWindow` because that method has been deprecated, replaced with `*.tabs.query({ currentWindow: true })` which seems to work fine in both browsers